### PR TITLE
Remove no restrictions tag

### DIFF
--- a/app/filters.js
+++ b/app/filters.js
@@ -70,12 +70,8 @@ addFilter('dateTime', govukDateTime)
 
 function statusClass(text) {
   switch (text) {
-    case 'Banned':
-      return 'govuk-tag--red'
     case 'Restrictions':
       return 'govuk-tag--red'
-    case 'No restrictions':
-      return 'govuk-tag--green'
   }
 }
 addFilter('statusClass', statusClass)

--- a/app/filters.js
+++ b/app/filters.js
@@ -69,7 +69,9 @@ addFilter('dateTime', govukDateTime)
 
 
 function statusClass(text) {
-  switch (text) {
+if (text == 'Restrictions'){
+  return 'govuk-tag-red';
+}
     case 'Restrictions':
       return 'govuk-tag--red'
   }

--- a/app/views/teachers/index.html
+++ b/app/views/teachers/index.html
@@ -43,10 +43,13 @@
                 </ul>
               {% endset %}
 
-              {{ govukTag({
-                text: teacher.status,
-                classes: teacher.status | statusClass
-              }) }}
+              {% if teacher.hasProhibitions == 'Yes' %}
+                {{ govukTag({
+                  text: teacher.status,
+                  classes: teacher.status | statusClass
+                }) }}
+              {% endif %}
+
               {{ govukSummaryList({
                 classes: 'govuk-summary-list--no-border app-summary-list--compact',
                 rows: [

--- a/app/views/teachers/show.html
+++ b/app/views/teachers/show.html
@@ -34,10 +34,12 @@
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <h1 class="govuk-heading-l govuk-!-margin-bottom-7">
         {{title}}
-        {{ govukTag({
-          text: teacher.status,
-          classes: teacher.status | statusClass
-        }) }}
+        {% if teacher.hasProhibitions == 'Yes' %}
+          {{ govukTag({
+            text: teacher.status,
+            classes: teacher.status | statusClass
+          }) }}
+        {% endif %}
       </h1>
 
       {# {% if user.organisation.name == teacher.organisation.name %}


### PR DESCRIPTION
### Background

We decided to remove the 'no restrictions' tag as it's potentially confusing. For example someone may not be able to teach because they have not passed their induction, but we’d still say ‘no restrictions’ because they don’t have a prohibition order or similar.

We think that it’s fine to only highlight restrictions and just say nothing when there’s no problem.

### Changes

I've changed the search results and record pages so that a tag is only displayed if there's a restriction. I also removed the code in filters.js which gave a colour to 'Restrictions' tags. At the same time I removed the code from there for the 'Banned' tag which is no longer used.

I did not remove the code in routes/teachers.js which sets the default teacher.status to 'No restrictions'. It may be useful to keep this explicit distinction. 

Search results with 'No restrictions' tag (before change)

![Search results with 'No restrictions' tag](https://github.com/DFE-Digital/check-the-record-of-a-teacher-prototype/assets/29047487/bdbc2447-c16c-43a6-a954-bdc3f23e37a4)

Search results without 'No restrictions' tag (after change)

![Search results without 'No restrictions' tag](https://github.com/DFE-Digital/check-the-record-of-a-teacher-prototype/assets/29047487/457dbb50-6ac2-4ea8-a5ee-0a5ce99137bf)

Teacher record with 'No restrictions' tag (before change)

![Teacher record with 'No restrictions' tag](https://github.com/DFE-Digital/check-the-record-of-a-teacher-prototype/assets/29047487/d5b0f0f2-ca51-4b6a-8663-fd91b9f482e1)

Teacher record without 'No restrictions' tag (after change)

![Teacher record without 'No restrictions' tag](https://github.com/DFE-Digital/check-the-record-of-a-teacher-prototype/assets/29047487/aed4a7c4-60f4-4a71-b680-05249f73a9c0)
