### PR TITLE
Removing the term 'restrictions'

### DIFF
--- a/app/views/teachers/index.html
+++ b/app/views/teachers/index.html
@@ -33,7 +33,7 @@
                 <a class="govuk-link--no-visited-state" href="/teachers/{{teacher.id}}">{{teacher.firstName}} {{teacher.lastName}}</a>
               </h2>
 
-              {% set restrictions %}
+              {# {% set restrictions %}
                 <ul class="govuk-list govuk-list--spaced govuk-!-font-size-16">
                   {% for restriction in teacher.restrictions %}
                     <li>
@@ -41,14 +41,14 @@
                     </li>
                   {% endfor %}
                 </ul>
-              {% endset %}
+              {% endset %} #}
 
-              {% if teacher.hasProhibitions == 'Yes' %}
+              {# {% if teacher.hasProhibitions == 'Yes' %}
                 {{ govukTag({
                   text: teacher.status,
                   classes: teacher.status | statusClass
                 }) }}
-              {% endif %}
+              {% endif %} #}
 
               {{ govukSummaryList({
                 classes: 'govuk-summary-list--no-border app-summary-list--compact',
@@ -68,15 +68,7 @@
                     value: {
                       text: teacher.dob | date
                     }
-                  },
-                  {
-                    key: {
-                      text: "Restrictions"
-                    },
-                    value: {
-                      html: restrictions
-                    }
-                  } if teacher.restrictions.length
+                  }
                 ]
               }) }}
             </div>

--- a/app/views/teachers/show.html
+++ b/app/views/teachers/show.html
@@ -34,12 +34,12 @@
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <h1 class="govuk-heading-l govuk-!-margin-bottom-7">
         {{title}}
-        {% if teacher.hasProhibitions == 'Yes' %}
+        {# {% if teacher.hasProhibitions == 'Yes' %}
           {{ govukTag({
             text: teacher.status,
             classes: teacher.status | statusClass
           }) }}
-        {% endif %}
+        {% endif %} #}
       </h1>
 
       {# {% if user.organisation.name == teacher.organisation.name %}
@@ -49,22 +49,22 @@
       {% endif %} #}
 
       {% if teacher.hasProhibitions == 'Yes' %}
-          <h2 class="govuk-heading-m">
+          {# <h2 class="govuk-heading-m">
             Restrictions
-          </h2>
+          </h2> #}
         {% set inset %}
 
           {% for restriction in teacher.restrictions %}
-            <h3 class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-margin-top-0">
+            <h2 class="govuk-heading-m govuk-!-margin-bottom-1 govuk-!-margin-top-0">
               {{restriction.type.label}}
-            </h3>
+            </h2>
             <p class="govuk-!-margin-bottom-1">
-             {{restriction.date | date}}
+             {# {{restriction.date | date}} #}
               {% if restriction.dateForReview %}
                 (Will be reviewed {{restriction.dateForReview | date}})
               {% endif %}
             </p>
-            <p class="govuk-hint">{{restriction.notes}}</p>
+            <p class="govuk-body">{{restriction.notes}}</p>
           {% endfor %}
 
 


### PR DESCRIPTION
We've decided not to use the word 'restrictions' for the alerts we show on teacher records. Some alerts do not restrict people from teaching.

We could have used another term but it would have to be very generic. We've decided instead to:

- remove the 'restrictions' tag from the results and record pages
- remove the description of the restriction from the results page
- remove the h2 'restrictions' heading from the record page
- use the restriction type as the h2 heading on the record page
- change the restriction description to body text instead of hint text