### PR TITLE
Fix search again link

### DIFF
--- a/app/views/teachers/index.html
+++ b/app/views/teachers/index.html
@@ -48,7 +48,7 @@ text: "Search results"
       {{ data | isoDateFromDateInput("date") | govukDate }}.
     </p>
 
-    <p><a href="/">Search again</a></p>
+    <p><a href="/index">Search again</a></p>
     {% else %}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
@@ -142,7 +142,7 @@ text: "Search results"
             {{pagination.totalCount}} pages</p>
             {% endif %}
 
-            <p><a href="/">Search again</a></p>
+            <p><a href="/index">Search again</a></p>
 
         </div>
         {% endif %}


### PR DESCRIPTION
The 'search again' link on the search results page was pointing to the sign in page. Updated to the search index page.